### PR TITLE
fix: update model IDs to include OpenAI namespace for consistency

### DIFF
--- a/apps/www/src/lib/constants.ts
+++ b/apps/www/src/lib/constants.ts
@@ -176,7 +176,7 @@ export const models: Record<string, Model> = {
     features: ["vision", "fast", "reasoning", "tools"],
   },
   "gpt-oss-120b": {
-    id: "gpt-oss-120b",
+    id: "openai/gpt-oss-120b",
     name: "gpt-oss-120b",
     description: "Most powerful open-source GPT model.",
     author: "OpenAI",
@@ -185,7 +185,7 @@ export const models: Record<string, Model> = {
     features: ["fast", "tools"],
   },
   "gpt-oss-20b": {
-    id: "gpt-oss-20b",
+    id: "openai/gpt-oss-20b",
     name: "gpt-oss-20b",
     description: "Medium-sized open-source GPT model.",
     author: "OpenAI",


### PR DESCRIPTION
This pull request updates the model identifiers for the open-source GPT models in the `apps/www/src/lib/constants.ts` file to use the new naming convention prefixed with `openai/`.

Model identifier updates:

* Changed the `id` for `gpt-oss-120b` from `gpt-oss-120b` to `openai/gpt-oss-120b` to align with the new naming convention.
* Changed the `id` for `gpt-oss-20b` from `gpt-oss-20b` to `openai/gpt-oss-20b` for consistency with updated model references.